### PR TITLE
vertor_matrix dot without blas

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 * Gustav Larsson
 * Ivan Ukhov
+* Senzaki Uji

--- a/src/tensor/dot.rs
+++ b/src/tensor/dot.rs
@@ -30,6 +30,25 @@ macro_rules! add_impl {
                         }
                     }
                     t3
+                } else if self.ndim() == 1 && rhs.ndim() == 2 {
+                    // TODO dot(vector, matrix) with blas
+                    assert_eq!(self.shape[0], rhs.shape[0]);
+                    let mut t3 = Tensor::empty(&[rhs.shape[1]]);
+                    {
+                        let mut data = t3.slice_mut();
+                        
+                        // Naive implementation, BLAS will be much faster
+                        for i in 0..rhs.shape[1] {
+                            let mut v = 0.0;
+                            for k in 0..rhs.shape[0] {
+                                v += self.data[k] * rhs.get2(k, i
+                                );
+                            }
+                            data[i] = v;
+                        }
+                    }
+                    t3
+
                 } else if self.ndim() == 2 && rhs.ndim() == 2 {
                     assert_eq!(self.shape[1], rhs.shape[0]);
                     let mut t3 = Tensor::empty(&[self.shape[0], rhs.shape[1]]);

--- a/tests/dot.rs
+++ b/tests/dot.rs
@@ -37,6 +37,14 @@ macro_rules! add_impl {
                 let answer = T::fscalar(-2.0);
                 assert!(t1.dot(&t2) == answer);
             }
+
+            #[test]
+            fn vector_matrix_1() {
+                let t1 = T::new(vec![1.0, 2.0]);
+                let t2 = T::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).reshape(&[2, 3]);
+                let answer = T::new(vec![9.0, 12.0, 15.0]);
+                assert!(t1.dot(&t2) == answer);
+            }
         }
     )
 }


### PR DESCRIPTION
Hi. 

It seems that the vector.dot(matrix) is not supported yet both in numeric library and blas library. Therefore I just add some naive code that make the dot product directly..

Example:
Given a 1D tensor [1.0,  2.0] and a 2D tensor [1.0, 2.0, 3.0; 4.0, 5.0, 6.0], the dot result is 1D tensor [9.0, 12.0, 15.0] 

[Dev]
src/tensor/dot.rs
[Tests]
tests/dot.rs

